### PR TITLE
Fix caster list bug and profile page team list

### DIFF
--- a/src/screens/Profile.js
+++ b/src/screens/Profile.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import get from 'lodash.get'
-import { PageTitle, PageSubtitle, H2, UtilityButton } from '../components/elements'
+import { PageTitle, PageSubtitle, H2, H3, UtilityButton } from '../components/elements'
 import Chrome from '../components/Chrome'
 import SingleTeam from '../components/SingleTeam'
 import fetch from '../modules/fetch-with-headers'
@@ -145,7 +145,15 @@ function Profile () {
                         ? (
                           <div>
                             <H2>Teams</H2>
-                            { profile.player.teams.map(x => (
+                            <br />
+                            <H3>Active</H3>
+                            { profile.player.teams.filter(x => x.is_active).map(x => (
+                              <div key={`${x.id}-${x.name}`} className='my-2'>
+                                <SingleTeam className='text-md' team={x} />
+                              </div>
+                            ))}
+                            <H3>Past</H3>
+                            { profile.player.teams.filter(x => !x.is_active).map(x => (
                               <div key={`${x.id}-${x.name}`} className='my-2'>
                                 <SingleTeam className='text-md' team={x} />
                               </div>

--- a/src/screens/Team.js
+++ b/src/screens/Team.js
@@ -179,11 +179,9 @@ function Team () {
       })
 
       // get our casters (this is non-blocking)
-      fetch(`${getApiUrl()}casters/`)
+      fetch(`${getApiUrl()}casters/?is_active=true&limit=30`)
         .then(data => data.json())
-        .then(data => setCasters(data
-          .results
-          .filter(x => x.is_active)))
+        .then(data => setCasters(data.results))
         .catch(handleError)
     }
 
@@ -269,7 +267,6 @@ function Team () {
                                       { casters.map(x => <option key={`caster-${x.id}`} value={`${x.id}`}>{x.name.substr(0, 20)}{x.name.length > 20 ? '...' : ''}</option>) }
                                     </select>
                                   ) : null }
-
                                 { match.start_time === null && parseInt(userId) === parseInt(team.captain.id) && !match.result
                                   ? (
                                     <div className='flex justify-between'>


### PR DESCRIPTION
On the match box we were running into the same pagination issue, so using the correct querystring. 

On the profile page, showing a designation between active and past teams. 