### PR TITLE
Prelaunch Fixes

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -4,6 +4,7 @@ function Footer () {
   return (
     <footer className='p-2 lg:px-8'>
       <p className='text-gray-1 text-center'>This site and its ventures are unaffiliated with LiquidBit, and are not official productions for Killer Queen Black</p>
+      <div className='text-white text-sm text-center'>With ❤️ from Hattrickswayze, Dadcore, and Prosive</div>
     </footer>
   )
 }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -44,7 +44,7 @@ function Header () {
       <nav className='flex items-center'>
         <NavItem to='/register' className={`${linkString} text-gray-1`}>Register</NavItem>
         <NavItem to='/circuits' className={`${linkString} text-gray-1`}>Circuits</NavItem>
-        <NavItem to='/teams' className={`${linkString} text-gray-1`}>Teams</NavItem>
+        {/* <NavItem to='/teams' className={`${linkString} text-gray-1`}>Teams</NavItem> */}
         <NavItem to='/casters' className={`${linkString} text-gray-1`}>Casters</NavItem>
         <NavItem to='/help' className={`${linkString} text-gray-1`}>Help</NavItem>
 

--- a/src/screens/Casters.js
+++ b/src/screens/Casters.js
@@ -30,6 +30,7 @@ function Teams () {
         loading
           ? <div>loading...</div>
           : (
+            <>
             <div>
               <PageTitle>Caster</PageTitle>
               {casters.map((caster) => (
@@ -38,8 +39,13 @@ function Teams () {
                 </div>
               ))}
             </div>
+            {casters.length == 0 
+            ? <span className="text-normal mb-2">Casters coming soon...</span>
+            : null }
+            </>
           )
       }
+      <div className="text-sm">Apply to be a caster <a href="https://forms.gle/E32TkhWY1K1frvru7" target="_blank">here</a>.</div>
     </Chrome>
   )
 }

--- a/src/screens/Casters.js
+++ b/src/screens/Casters.js
@@ -45,7 +45,7 @@ function Teams () {
             </>
           )
       }
-      <div className="text-sm">Apply to be a caster <a href="https://forms.gle/E32TkhWY1K1frvru7" target="_blank">here</a>.</div>
+      <div className="mt-5 text-sm">Apply to be a caster <a href="https://forms.gle/qVy83m72xVQRtgsDA" target="_blank">here</a>.</div>
     </Chrome>
   )
 }

--- a/src/screens/Circuits.js
+++ b/src/screens/Circuits.js
@@ -4,7 +4,7 @@ import Chrome from '../components/Chrome'
 import fetch from '../modules/fetch-with-headers'
 import getApiUrl from '../modules/get-api-url'
 import handleError from '../modules/handle-error'
-import { PageTitle, CenterContent } from '../components/elements'
+import { PageTitle, CenterContent, PageSubtitle } from '../components/elements'
 
 function Circuits () {
   const [loading, setLoading] = useState(true)
@@ -31,7 +31,12 @@ function Circuits () {
           : (
             <div>
               <PageTitle>Circuits</PageTitle>
-              { leagues.map(x => (<Link key={`${x.name}`} className='block text-lg' to={`/circuits/${x.id}`}>{x.name}</Link>)) }
+              { leagues.map(x => (
+              <>
+              <PageSubtitle style={{ marginTop: '0rem', marginBottom: '-0.25rem' }}>{x.season.name}</PageSubtitle>
+              <Link key={`${x.name}`} className='block text-lg mb-2' to={`/circuits/${x.id}`}>{x.name}</Link>
+              </>
+              )) }
             </div>
           )
       }

--- a/src/screens/Profile.js
+++ b/src/screens/Profile.js
@@ -147,6 +147,7 @@ function Profile () {
                             <H2>Teams</H2>
                             <br />
                             <H3>Active</H3>
+                            <br />
                             { profile.player.teams.filter(x => x.is_active).map(x => (
                               <div key={`${x.id}-${x.name}`} className='my-2'>
                                 <SingleTeam className='text-md' team={x} />

--- a/src/screens/Profile.js
+++ b/src/screens/Profile.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import get from 'lodash.get'
-import { PageTitle, PageSubtitle, H2, H3, UtilityButton } from '../components/elements'
+import { PageTitle, PageSubtitle, H2, H3, UtilityButton, FormBox } from '../components/elements'
 import Chrome from '../components/Chrome'
 import SingleTeam from '../components/SingleTeam'
 import fetch from '../modules/fetch-with-headers'
@@ -90,7 +90,7 @@ function Profile () {
           ? <div>loading...</div>
           : (
             <div>
-              <div className='flex items-center'>
+              <div className='flex items-center mb-4'>
                 <PageTitle className='truncate max-w-xs sm:max-width-sm md:max-w-full' style={{ marginBottom: 0 }}>{profile.player.name}</PageTitle>
                 {!editProfile
                   ? (
@@ -114,17 +114,24 @@ function Profile () {
                 editProfile
                   ? (
                     <div className='flex flex-col'>
+                      <FormBox>
+                      <label for="pronouns">Pronouns</label>
                       <input
-                        className='shadow inline-block appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline'
+                        className='shadow inline-block appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline lg:w-1/2'
                         placeholder='Pronouns'
                         name='pronouns'
                         value={pronouns}
                         onChange={e => setPronouns(e.target.value)}
                         required />
+                      </FormBox>
+                      <FormBox>
+                      <label for="bio">Bio</label>
                       <textarea
-                        className='mt-2 shadow inline-block appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline'
+                        className='mt-2 shadow inline-block appearance-none border rounded py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline lg:w-1/2' 
+                        name="bio"
                         onChange={e => setBio(e.target.value)}
                         value={bio} />
+                      </FormBox>
                       <div className='mt-2 flex'>
                         <UtilityButton type='submit' onClick={handleSubmit}>
                           Update
@@ -153,12 +160,21 @@ function Profile () {
                                 <SingleTeam className='text-md' team={x} />
                               </div>
                             ))}
+                            {
+                              profile.player.teams.filter(x => x.is_active).length == 0 
+                              ? <p>None</p> : null
+                            }
                             <H3>Past</H3>
+                            <br />
                             { profile.player.teams.filter(x => !x.is_active).map(x => (
                               <div key={`${x.id}-${x.name}`} className='my-2'>
                                 <SingleTeam className='text-md' team={x} />
                               </div>
                             ))}
+                            {
+                              profile.player.teams.filter(x => !x.is_active).length == 0 
+                              ? <p>None</p> : null
+                            }
                           </div>
                         ) : null}
                     </div>


### PR DESCRIPTION
1. Global Nav: hide 'teams' link in navbar as it's causing confusion in users, clarify purpose of page post-launch
2. Profile Page: add label to bio textarea field
4. Casters Page: if no casters, then, "Casters coming soon!"
5. Casters Page: Add link to the casters page that says "Apply to be a BGL caster here" (https://forms.gle/E32TkhWY1K1frvru7)
6. Circuits Page: Add League & Season name above group of circuits (or above each circuit name, whatever is easier)
7. Profile page: If you are not on any active teams, either hide "Active" header or put text "None" below "Active" header