### PR TITLE
Using plain anchor tag for offsite caster stream link, not internal l…

### DIFF
--- a/src/screens/Caster.js
+++ b/src/screens/Caster.js
@@ -36,9 +36,9 @@ function Teams () {
                 {caster.player.name_phonetic || ''} {caster.player.pronouns ? `(${caster.player.pronouns})` : ''}</PageSubtitle>
               <div className='mt-4'>{caster.player.bio}</div>              
 
-              <Link to={caster.stream_link} className={`flex mt-5 ${caster.player.twitch_username ? "" : "hidden"}`}>
+              <a href={caster.stream_link} class={`flex mt-5 ${caster.player.twitch_username ? "" : "hidden"}`}>
                   twitch.tv/{ caster.player.twitch_username }
-              </Link>                              
+              </a>         
 
               <span></span>
             </div>


### PR DESCRIPTION
…ink component.

My bad I just used the <Link> component without trying to understand it/testing it well, think it's only supposed to be used for internal links maybe. It was not working to link to offsite links like to a twitch stream.

Just using plain anchor tag now for caster links.