### PR TITLE
Sort matches on team page with oldest first

### DIFF
--- a/src/screens/Team.js
+++ b/src/screens/Team.js
@@ -139,7 +139,7 @@ function Team () {
         .then((data) => data.json())
         .then((data) => {
           setTeam(data)
-          setMatches([...data.home_matches, ...data.away_matches])
+          setMatches([...data.home_matches, ...data.away_matches].sort((a, b) => (a.start_time > b.start_time ? 1 : -1)))
 
           setName(data.name)
           fetch(`${getApiUrl()}circuits/${data.circuit}/`)


### PR DESCRIPTION
Tested with http://localhost:3001/teams/136 which has two matches, one from home and one from away.  (Sadly, they were in that order originally, so all I did was prove the `sort` doesn't error out...)

Edit: Oh, and change port to 3000 if you want to test.  I just use 3001 because I have another local npm app running 100% of the time

Edit 2: Realized I could point it to prod data.  Confirmed that match results for Snailed It! were sorted correctly now