### PR TITLE
Use original state of Profile object to backout on edits

### DIFF
--- a/src/screens/Profile.js
+++ b/src/screens/Profile.js
@@ -52,12 +52,27 @@ function Profile () {
     fetch(`${getApiUrl()}players/${profile.player.id}/`, requestOptions)
       .then(res => res.json())
       .then((res) => {
+        // If we don't patch profile here with the patched object, then backing out after first set of edits later will
+        // return to an earlier value, because profile.player is used in reset.
+        profile.player = res
+        setProfile(profile)
         setNamePhonetic(res.name_phonetic)
         setPronouns(res.pronouns)
         setBio(res.bio)
         toggleEditProfile()
       })
       .catch(handleError)
+  }
+
+  function handleCancel (e) {
+    e.preventDefault()
+
+    // Reset all three fields
+    setNamePhonetic(profile.player.name_phonetic)
+    setPronouns(profile.player.pronouns)
+    setBio(profile.player.bio)
+
+    toggleEditProfile()
   }
 
   // Function to copy user token to clipboard on button click
@@ -168,7 +183,7 @@ function Profile () {
                           Update
                         </UtilityButton>
 
-                        <UtilityButton className={'ml-2'} onClick={toggleEditProfile}>
+                        <UtilityButton className={'ml-2'} onClick={handleCancel}>
                           Cancel
                         </UtilityButton>
                       </div>


### PR DESCRIPTION
Previous behavior:
We update the in-memory state `onChange` for any of the fields.  Then, `onSubmit`, we send those new state values to the backend and get back a player (not profile) patch object.  However, because we updated the in-memory state `onChange`, when we `cancel` we actually render the new values.

Summary of fix:
1. Reset in-memory state to the values from `profile` on cancel (which was how they were derived originally.)
2. On successful update, patch `player` on `profile` with the new info.  (Side-effect:  If _another_ change was made to `player`, it'll now be rendered.  Probably ok.)

NOTE: I feel this is a bit messy.  I don't like how this state is handled.  It feels like a `pendingPronouns` state would be better, then we move send that to `setPronouns` later?  I'm willing to change this PR to that if it's preferred.