### PR TITLE
Player match profile for teams

### DIFF
--- a/src/components/PlayerTeamList.js
+++ b/src/components/PlayerTeamList.js
@@ -1,0 +1,37 @@
+import React from 'react'
+import {H2, H3} from './elements'
+
+import SingleTeam from './SingleTeam'
+
+function PlayerTeamList ({ player, className = ''}) {
+  return (
+    <div>
+      <H2>Teams</H2>
+      <br />
+      <H3>Active</H3>
+      <br />
+      { player.teams.filter(x => x.is_active).map(x => (
+        <div key={`${x.id}-${x.name}`} className='my-2'>
+          <SingleTeam className='text-md' team={x} />
+        </div>
+      ))}
+      {
+        player.teams.filter(x => x.is_active).length === 0
+          ? <p>None</p> : null
+      }
+      <H3>Past</H3>
+      <br />
+      { player.teams.filter(x => !x.is_active).map(x => (
+        <div key={`${x.id}-${x.name}`} className='my-2'>
+          <SingleTeam className='text-md' team={x} />
+        </div>
+      ))}
+      {
+        player.teams.filter(x => !x.is_active).length === 0
+          ? <p>None</p> : null
+      }
+    </div>
+  )
+}
+
+export default PlayerTeamList

--- a/src/screens/Player.js
+++ b/src/screens/Player.js
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom'
 import cookie from 'react-cookies'
 import { PageTitle, PageSubtitle, H3, AvatarContainer } from '../components/elements'
 import Chrome from '../components/Chrome'
-import SingleTeam from '../components/SingleTeam'
+import PlayerTeamList from "../components/PlayerTeamList";
 import fetch from '../modules/fetch-with-headers'
 import getApiUrl from '../modules/get-api-url'
 import handleError from '../modules/handle-error'
@@ -72,14 +72,7 @@ function Profile () {
                 </div>
 
               </div>
-              <div className='clear'>
-                <H3 className>Teams</H3>
-                { player.teams.map(x => (
-                  <div key={x.id}>
-                    <SingleTeam className='text-md' team={x} />
-                  </div>
-                ))}
-              </div>
+              <PlayerTeamList player={player} className='clear' />
             </div>
           )
       }

--- a/src/screens/Profile.js
+++ b/src/screens/Profile.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import get from 'lodash.get'
 import { PageTitle, PageSubtitle, H2, H3, UtilityButton, AvatarContainer, FormBox } from '../components/elements'
 import Chrome from '../components/Chrome'
-import SingleTeam from '../components/SingleTeam'
+import PlayerTeamList from "../components/PlayerTeamList";
 import fetch from '../modules/fetch-with-headers'
 import getApiUrl from '../modules/get-api-url'
 import handleError from '../modules/handle-error'
@@ -193,32 +193,7 @@ function Profile () {
 
                       { get(profile, 'player.teams')
                         ? (
-                          <div>
-                            <H2>Teams</H2>
-                            <br />
-                            <H3>Active</H3>
-                            <br />
-                            { profile.player.teams.filter(x => x.is_active).map(x => (
-                              <div key={`${x.id}-${x.name}`} className='my-2'>
-                                <SingleTeam className='text-md' team={x} />
-                              </div>
-                            ))}
-                            {
-                              profile.player.teams.filter(x => x.is_active).length === 0
-                                ? <p>None</p> : null
-                            }
-                            <H3>Past</H3>
-                            <br />
-                            { profile.player.teams.filter(x => !x.is_active).map(x => (
-                              <div key={`${x.id}-${x.name}`} className='my-2'>
-                                <SingleTeam className='text-md' team={x} />
-                              </div>
-                            ))}
-                            {
-                              profile.player.teams.filter(x => !x.is_active).length === 0
-                                ? <p>None</p> : null
-                            }
-                          </div>
+                          <PlayerTeamList player={profile.player} />
                         ) : null}
                     </div>
                   </>


### PR DESCRIPTION
Recommend going commit by commit.  Unfortunately, Player API does not have access to `circuit_display`, so I can't actually render that.  I'll add a backend ticket to expose that shortly.

Before (Player page):
<img width="344" alt="Screen Shot 2021-04-20 at 7 02 02 PM" src="https://user-images.githubusercontent.com/1693224/115486192-03fa3000-a20b-11eb-84b4-e8994cc0ca62.png">


After (Player page):
<img width="364" alt="Screen Shot 2021-04-20 at 7 02 44 PM" src="https://user-images.githubusercontent.com/1693224/115486200-08264d80-a20b-11eb-8be5-fa45cfe79eca.png">


Profile page, for comparison sake:
<img width="361" alt="Screen Shot 2021-04-20 at 7 01 56 PM" src="https://user-images.githubusercontent.com/1693224/115486206-0a88a780-a20b-11eb-86e7-7b4868a679ca.png">
