### PR TITLE
Subtly muted non today-days, further foregrounded today

### DIFF
--- a/src/screens/Home.js
+++ b/src/screens/Home.js
@@ -34,8 +34,14 @@ const EventItem = styled.div`
 
 function highlightCurrentDay (dayOffset = 0) {
   return moment().format('M/D') === moment().startOf('isoweek').add(dayOffset, 'days').format('M/D')
-    ? 'bg-blue-700 text-yellow-2'
-    : 'bg-blue-3'
+    ? 'bg-blue-700 text-white'
+    : 'bg-blue-3 text-blue-200'
+}
+
+function highlightCurrentDayHeader (dayOffset = 0) {
+  return moment().format('M/D') === moment().startOf('isoweek').add(dayOffset, 'days').format('M/D')
+    ? 'text-blue-300'
+    : 'text-blue-4'
 }
 
 function SingleEvent ({ event }) {
@@ -65,7 +71,7 @@ function TvGuide ({ schedule }) {
     <div style={{ backgroundImage: 'repeating-linear-gradient(45deg, #202020, #202020 30px, #222 30px, #222 60px)' }} className='grid grid-cols-1 shadow-lg md:grid-cols-2 lg:grid-cols-7 md:rounded-t-md'>
       <DayColumn>
         <div className={`p-1 mt-1 font-bold text-center border-b border-gray-800 md:mt-0 md:p-2 md:rounded-tl-md md:border-none ${highlightCurrentDay(0)}`}>
-          <div className='text-xs uppercase text-blue-4'>{moment().startOf('isoweek').format('ddd')}</div>
+          <div className={`text-xs uppercase ${highlightCurrentDayHeader(0)}`}>{moment().startOf('isoweek').format('ddd')}</div>
           <div>{moment().startOf('isoweek').format('M/D')}</div>
         </div>
         <CalendarDark>
@@ -80,7 +86,7 @@ function TvGuide ({ schedule }) {
       </DayColumn>
       <DayColumn>
         <div className={`p-1 mt-1 font-bold text-center border-b border-gray-800 md:mt-0 md:p-2 md:border-none ${highlightCurrentDay(1)}`}>
-          <div className='text-xs uppercase text-blue-4'>{moment().startOf('isoweek').add(1, 'days').format('ddd')}</div>
+          <div className={`text-xs uppercase ${highlightCurrentDayHeader(1)}`}>{moment().startOf('isoweek').add(1, 'days').format('ddd')}</div>
           <div>{moment().startOf('isoweek').add(1, 'days').format('M/D')}</div>
         </div>
         <CalendarDark>
@@ -95,7 +101,7 @@ function TvGuide ({ schedule }) {
       </DayColumn>
       <DayColumn>
         <div className={`p-1 mt-1 font-bold text-center border-b border-gray-800 md:mt-0 md:p-2 md:border-none ${highlightCurrentDay(2)}`}>
-          <div className='text-xs uppercase text-blue-4'>{moment().startOf('isoweek').add(2, 'days').format('ddd')}</div>
+          <div className={`text-xs uppercase ${highlightCurrentDayHeader(2)}`}>{moment().startOf('isoweek').add(2, 'days').format('ddd')}</div>
           <div>{moment().startOf('isoweek').add(2, 'days').format('M/D')}</div>
         </div>
         <CalendarDark>
@@ -110,7 +116,7 @@ function TvGuide ({ schedule }) {
       </DayColumn>
       <DayColumn>
         <div className={`p-1 mt-1 font-bold text-center border-b border-gray-800 md:mt-0 md:p-2 md:border-none ${highlightCurrentDay(3)}`}>
-          <div className='text-xs uppercase text-blue-4'>{moment().startOf('isoweek').add(3, 'days').format('ddd')}</div>
+          <div className={`text-xs uppercase ${highlightCurrentDayHeader(3)}`}>{moment().startOf('isoweek').add(3, 'days').format('ddd')}</div>
           <div>{moment().startOf('isoweek').add(3, 'days').format('M/D')}</div>
         </div>
         <CalendarDark>
@@ -125,7 +131,7 @@ function TvGuide ({ schedule }) {
       </DayColumn>
       <DayColumn>
         <div className={`p-1 mt-1 font-bold text-center border-b border-gray-800 md:mt-0 md:p-2 md:border-none ${highlightCurrentDay(4)}`}>
-          <div className='text-xs uppercase text-blue-4'>{moment().startOf('isoweek').add(4, 'days').format('ddd')}</div>
+          <div className={`text-xs uppercase ${highlightCurrentDayHeader(4)}`}>{moment().startOf('isoweek').add(4, 'days').format('ddd')}</div>
           <div>{moment().startOf('isoweek').add(4, 'days').format('M/D')}</div>
         </div>
         <CalendarDark>
@@ -140,7 +146,7 @@ function TvGuide ({ schedule }) {
       </DayColumn>
       <DayColumn>
         <div className={`p-1 mt-1 font-bold text-center border-b border-gray-800 md:mt-0 md:p-2 md:border-none ${highlightCurrentDay(5)}`}>
-          <div className='text-xs uppercase text-blue-4'>{moment().startOf('isoweek').add(5, 'days').format('ddd')}</div>
+          <div className={`text-xs uppercase ${highlightCurrentDayHeader(5)}`}>{moment().startOf('isoweek').add(5, 'days').format('ddd')}</div>
           <div>{moment().startOf('isoweek').add(5, 'days').format('M/D')}</div>
         </div>
         <CalendarDark>
@@ -155,7 +161,7 @@ function TvGuide ({ schedule }) {
       </DayColumn>
       <DayColumn>
         <div className={`p-1 mt-1 font-bold text-center border-b border-gray-800 md:mt-0 md:p-2 md:rounded-tr-md md:border-none ${highlightCurrentDay(6)}`}>
-          <div className='text-xs uppercase text-blue-4'>{moment().startOf('isoweek').add(6, 'days').format('ddd')}</div>
+          <div className={`text-xs uppercase ${highlightCurrentDayHeader(6)}`}>{moment().startOf('isoweek').add(6, 'days').format('ddd')}</div>
           <div>{moment().startOf('isoweek').add(6, 'days').format('M/D')}</div>
         </div>
         <CalendarDark>


### PR DESCRIPTION
I tweaked the colors for todays day of the week, to further make them feel foregrounded...and likewise since you can't get any more foreground than text-white, i changed other days to text-blue-200 so they are slightly backgrounded.

The goal is to make today's date feel like foreground, the text as well as the background. Here's a screenshot.

<img width="1271" alt="Screen Shot 2021-05-05 at 2 22 36 PM" src="https://user-images.githubusercontent.com/1757912/117197401-63307680-adad-11eb-9a5b-7c000e52df7f.png">

If you're cool with this approach merge away, if you are in love with the gold text tho we might be able to figure something else out.