### PR TITLE
Fix match sorting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# IntelliJ IDEA
+*.iml
+.idea/*

--- a/src/screens/Team.js
+++ b/src/screens/Team.js
@@ -140,7 +140,17 @@ function Team () {
         .then((data) => data.json())
         .then((data) => {
           setTeam(data)
-          setMatches([...data.home_matches, ...data.away_matches].sort((a, b) => (a.start_time > b.start_time ? 1 : -1)))
+          setMatches([...data.home_matches, ...data.away_matches].sort(
+            (a, b) => (a.round.number - 0.0 > b.round.number - 0.0 ? 1 : -1)
+          ).sort(
+            (a, b) => {
+              if (a.start_time == null || b.start_time == null || a.start_time == b.start_time) {
+                return 0
+              } else {
+                return (a.start_time > b.start_time ? 1 : -1)
+              }
+            }
+          ))
           setMatchesWon(data.wins)
           setMatchesLost(data.losses)
 


### PR DESCRIPTION
Things tested:
- Team with good mix of home/away (http://localhost:3001/teams/1098)
- Team that is home only (http://localhost:3001/teams/1101)
- Grand champs reset (http://localhost:3001/teams/847/)
- IGL bye match (http://localhost:3001/teams/1045/)