### PR TITLE
Show team record in mobile view

### DIFF
--- a/src/screens/Team.js
+++ b/src/screens/Team.js
@@ -244,7 +244,7 @@ function Team () {
                       : (
                         <div className='flex flex-col'>
                           <PageTitle className='max-w-xs truncate sm:max-width-sm md:max-w-full' style={{ marginBottom: 0 }}>
-                            {name} ({matchesWon} - {matchesLost})
+                            {name} <span className='xs:hidden md:inline'>({matchesWon} - {matchesLost})</span>
                           </PageTitle>
                           { parseInt(userId) === parseInt(team.captain.id)
                           // captain only view
@@ -264,7 +264,10 @@ function Team () {
 
                   </div>
 
-                  <div className='flex self-center justify-center text-lg text-right md:block font-head'><Link className='text-white' to={`/circuits/${circuit.id}/`}>{circuit.name}</Link></div>
+                  <div className='flex self-center justify-center text-lg text-right md:block font-head'>
+                    <Link className='text-white' to={`/circuits/${circuit.id}/`}>{circuit.name}</Link>
+                    <span className='xs:inline md:hidden pl-1'>({matchesWon} - {matchesLost})</span>
+                  </div>
                 </div>
               </div>
 


### PR DESCRIPTION
Took dadcore's advice and showing it differently based off screen size.  CREAM screenshot shows that it's properly hidden on mobile for short team names.  BLC mobile screenshot shows why we need it.  Other BLC screenshots are just for reference

![Screen Shot 2021-06-09 at 5 42 49 PM](https://user-images.githubusercontent.com/1693224/121447240-20346680-c94a-11eb-8983-2c5a88b46f57.png)



![Screen Shot 2021-06-09 at 5 40 01 PM](https://user-images.githubusercontent.com/1693224/121447106-dcd9f800-c949-11eb-8811-6be46dbed5ed.png)
![Screen Shot 2021-06-09 at 5 40 05 PM](https://user-images.githubusercontent.com/1693224/121447109-de0b2500-c949-11eb-8bf7-24190fab4b15.png)
![Screen Shot 2021-06-09 at 5 40 00 PM](https://user-images.githubusercontent.com/1693224/121447101-d9df0780-c949-11eb-91a7-266b3ed04379.png)
