### PR TITLE
Optional Spoilers on homepage TV Guide

### DIFF
--- a/src/screens/Home.js
+++ b/src/screens/Home.js
@@ -45,7 +45,6 @@ function highlightCurrentDayHeader (dayOffset = 0, roundOffset = 0) {
 
 function SingleEvent ({ event, showSpoilers = true}) {
   const [reveal, setReveal] = useState(false)
-  const onClick = () => setReveal(true)
   return (
     <EventItem key={`${event.home.name}-${event.away.name}-${event.start_time}`}>
       <p className='py-1 pl-1 text-xs text-yellow-1'>{formatTime(event.start_time)}</p>
@@ -77,7 +76,7 @@ function SingleEvent ({ event, showSpoilers = true}) {
               <span className='pl-2 mr-2 -ml-1'>
               <svg class="w-3 text-yellow-3" xmlns="http://www.w3.org/2000/svg" data-name="Layer 1" viewBox="0 0 1456.2 1161.79"><def/><path class="" fill="currentColor" d="M1360.56 626.71c127.52-127.52 127.52-335 0-462.51a325.16 325.16 0 00-107.75-71.57q2-27.11 2.84-54.35A37.21 37.21 0 001218.4 0H237.8a37.21 37.21 0 00-37.25 38.28q.82 27.23 2.84 54.35A325.16 325.16 0 0095.64 164.2c-127.52 127.52-127.52 335 0 462.51 62.66 62.67 189.09 139.61 307.44 187.1 46.74 18.76 100 36.14 152.16 44.45a1210.29 1210.29 0 01-147.7 253.48c-15.48 20.39-1.27 50 24 50h593.16c25.25 0 39.46-29.65 24-50A1210.29 1210.29 0 01901 858.26c52.11-8.31 105.43-25.69 152.16-44.45 118.31-47.49 244.73-124.43 307.4-187.1zM166.83 555.52c-88.26-88.26-88.26-231.87 0-320.13a225.73 225.73 0 0148.7-37C247.16 400.98 325 588.84 430.2 716.17c-115.29-47.83-219.05-116.28-263.37-160.65zm1073.84-357.16a225.73 225.73 0 0148.7 37c88.26 88.26 88.26 231.87 0 320.13-44.27 44.4-148.08 112.85-263.37 160.65 105.2-127.33 183.04-315.19 214.67-517.78z"/></svg>
             </span>
-            <span className='pr-1' onClick={onClick}>Click to show winner</span>
+            <span className='pr-1' onClick={() => setReveal(true)}>Click to show winner</span>
           </p>
         }
       </div>

--- a/src/screens/Home.js
+++ b/src/screens/Home.js
@@ -86,10 +86,7 @@ function SingleEvent ({ event, previousEventStartTime = 0, showSpoilers = true }
           <span className='pl-2 mr-2 -ml-1'>
               <svg class="w-3 text-yellow-3" xmlns="http://www.w3.org/2000/svg" data-name="Layer 1" viewBox="0 0 1456.2 1161.79"><def/><path class="" fill="currentColor" d="M1360.56 626.71c127.52-127.52 127.52-335 0-462.51a325.16 325.16 0 00-107.75-71.57q2-27.11 2.84-54.35A37.21 37.21 0 001218.4 0H237.8a37.21 37.21 0 00-37.25 38.28q.82 27.23 2.84 54.35A325.16 325.16 0 0095.64 164.2c-127.52 127.52-127.52 335 0 462.51 62.66 62.67 189.09 139.61 307.44 187.1 46.74 18.76 100 36.14 152.16 44.45a1210.29 1210.29 0 01-147.7 253.48c-15.48 20.39-1.27 50 24 50h593.16c25.25 0 39.46-29.65 24-50A1210.29 1210.29 0 01901 858.26c52.11-8.31 105.43-25.69 152.16-44.45 118.31-47.49 244.73-124.43 307.4-187.1zM166.83 555.52c-88.26-88.26-88.26-231.87 0-320.13a225.73 225.73 0 0148.7-37C247.16 400.98 325 588.84 430.2 716.17c-115.29-47.83-219.05-116.28-263.37-160.65zm1073.84-357.16a225.73 225.73 0 0148.7 37c88.26 88.26 88.26 231.87 0 320.13-44.27 44.4-148.08 112.85-263.37 160.65 105.2-127.33 183.04-315.19 214.67-517.78z"/></svg>
             </span>
-            { shouldDisplayWinner()
-              ? <span className='pr-1'>{event.result.winner}</span>
-              : <span className='pr-1 cursor-pointer'>Click to show winner</span>
-            }
+            <span className='pr-1'>{shouldDisplayWinner() ? event.result.winner : 'Click to show winner'}</span>
           </div>
         }
       </div>

--- a/src/screens/Home.js
+++ b/src/screens/Home.js
@@ -63,6 +63,7 @@ function hideDuplicatedTimestamp(currentEventStartTime, previousEventStartTime) 
 
 function SingleEvent ({ event, previousEventStartTime = 0, showSpoilers = true }) {
   const [reveal, setReveal] = useState(false)
+  const shouldDisplayWinner = () => showSpoilers || reveal
   return (
     <EventItem key={`${event.home.name}-${event.away.name}-${event.start_time}`}>
       <p className={`py-1 pl-1 text-xs text-yellow-1 ${hideDuplicatedTimestamp(event.start_time, previousEventStartTime)}`}>{formatTime(event.start_time)}</p>
@@ -80,22 +81,16 @@ function SingleEvent ({ event, previousEventStartTime = 0, showSpoilers = true }
           ? <a target='_blank' rel='noreferrer' className='flex items-center text-xs leading-loose text-purple-400' href={event.primary_caster.stream_link}><svg className='w-3 h-3 mr-1' fill='currentColor' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'> <defs /> <path fillRule='evenodd' d='M2.149 0L.537 4.119v16.836h5.731V24h3.224l3.045-3.045h4.657l6.269-6.269V0H2.149zm19.164 13.612l-3.582 3.582H12l-3.045 3.045v-3.045H4.119V2.149h17.194v11.463zm-3.582-7.343v6.262h-2.149V6.269h2.149zm-5.731 0v6.262H9.851V6.269H12z' clipRule='evenodd' /></svg>{event.primary_caster.name}</a>
           : <p className='text-xs italic'>Looking for caster</p> }
 
-        { (event.result && (showSpoilers || reveal))
-          && <p className='flex items-center justify-center w-1/2 px-1 py-1 my-2 ml-auto mr-auto font-bold text-center text-white border border-gray-700 rounded-full md:mt-2 md:mb-1 md:w-full text-2xs'>
-            <span className='pl-2 mr-2 -ml-1'>
-              <svg className='w-3 text-yellow-3' xmlns='http://www.w3.org/2000/svg' data-name='Layer 1' viewBox='0 0 1456.2 1161.79'><def /><path className='' fill='currentColor' d='M1360.56 626.71c127.52-127.52 127.52-335 0-462.51a325.16 325.16 0 00-107.75-71.57q2-27.11 2.84-54.35A37.21 37.21 0 001218.4 0H237.8a37.21 37.21 0 00-37.25 38.28q.82 27.23 2.84 54.35A325.16 325.16 0 0095.64 164.2c-127.52 127.52-127.52 335 0 462.51 62.66 62.67 189.09 139.61 307.44 187.1 46.74 18.76 100 36.14 152.16 44.45a1210.29 1210.29 0 01-147.7 253.48c-15.48 20.39-1.27 50 24 50h593.16c25.25 0 39.46-29.65 24-50A1210.29 1210.29 0 01901 858.26c52.11-8.31 105.43-25.69 152.16-44.45 118.31-47.49 244.73-124.43 307.4-187.1zM166.83 555.52c-88.26-88.26-88.26-231.87 0-320.13a225.73 225.73 0 0148.7-37C247.16 400.98 325 588.84 430.2 716.17c-115.29-47.83-219.05-116.28-263.37-160.65zm1073.84-357.16a225.73 225.73 0 0148.7 37c88.26 88.26 88.26 231.87 0 320.13-44.27 44.4-148.08 112.85-263.37 160.65 105.2-127.33 183.04-315.19 214.67-517.78z' /></svg>
-            </span>
-            <span className='pr-1'>{event.result.winner}</span>
-          </p>
-        }
-
-        { (event.result && (!showSpoilers && !reveal)) 
-          && <p className='flex items-center justify-center w-1/2 px-1 py-1 my-2 ml-auto mr-auto font-bold text-center text-white border border-gray-700 rounded-full md:mt-2 md:mb-1 md:w-full text-2xs'>
-              <span className='pl-2 mr-2 -ml-1'>
+        { event.result
+          && <div className={'flex items-center justify-center w-1/2 px-1 py-1 my-2 ml-auto mr-auto font-bold text-center text-white border border-gray-700 rounded-full md:mt-2 md:mb-1 md:w-full text-2xs ' + (!shouldDisplayWinner() ? 'cursor-pointer' : '')} onClick={ !shouldDisplayWinner() ? () => setReveal(true) : undefined }>
+          <span className='pl-2 mr-2 -ml-1'>
               <svg class="w-3 text-yellow-3" xmlns="http://www.w3.org/2000/svg" data-name="Layer 1" viewBox="0 0 1456.2 1161.79"><def/><path class="" fill="currentColor" d="M1360.56 626.71c127.52-127.52 127.52-335 0-462.51a325.16 325.16 0 00-107.75-71.57q2-27.11 2.84-54.35A37.21 37.21 0 001218.4 0H237.8a37.21 37.21 0 00-37.25 38.28q.82 27.23 2.84 54.35A325.16 325.16 0 0095.64 164.2c-127.52 127.52-127.52 335 0 462.51 62.66 62.67 189.09 139.61 307.44 187.1 46.74 18.76 100 36.14 152.16 44.45a1210.29 1210.29 0 01-147.7 253.48c-15.48 20.39-1.27 50 24 50h593.16c25.25 0 39.46-29.65 24-50A1210.29 1210.29 0 01901 858.26c52.11-8.31 105.43-25.69 152.16-44.45 118.31-47.49 244.73-124.43 307.4-187.1zM166.83 555.52c-88.26-88.26-88.26-231.87 0-320.13a225.73 225.73 0 0148.7-37C247.16 400.98 325 588.84 430.2 716.17c-115.29-47.83-219.05-116.28-263.37-160.65zm1073.84-357.16a225.73 225.73 0 0148.7 37c88.26 88.26 88.26 231.87 0 320.13-44.27 44.4-148.08 112.85-263.37 160.65 105.2-127.33 183.04-315.19 214.67-517.78z"/></svg>
             </span>
-            <span className='pr-1' onClick={() => setReveal(true)}>Click to show winner</span>
-          </p>
+            { shouldDisplayWinner()
+              ? <span className='pr-1'>{event.result.winner}</span>
+              : <span className='pr-1 cursor-pointer'>Click to show winner</span>
+            }
+          </div>
         }
       </div>
     </EventItem>

--- a/src/screens/Home.js
+++ b/src/screens/Home.js
@@ -43,7 +43,7 @@ function highlightCurrentDayHeader (dayOffset = 0, roundOffset = 0) {
     : 'text-blue-4'
 }
 
-function SingleEvent ({ event, showSpoilers = true}) {
+function SingleEvent ({ event, showSpoilers = true }) {
   const [reveal, setReveal] = useState(false)
   return (
     <EventItem key={`${event.home.name}-${event.away.name}-${event.start_time}`}>

--- a/src/screens/Home.js
+++ b/src/screens/Home.js
@@ -63,7 +63,7 @@ function SingleEvent ({ event, showSpoilers = true}) {
           ? <a target='_blank' rel='noreferrer' className='flex items-center text-xs leading-loose text-purple-400' href={event.primary_caster.stream_link}><svg className='w-3 h-3 mr-1' fill='currentColor' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'> <defs /> <path fillRule='evenodd' d='M2.149 0L.537 4.119v16.836h5.731V24h3.224l3.045-3.045h4.657l6.269-6.269V0H2.149zm19.164 13.612l-3.582 3.582H12l-3.045 3.045v-3.045H4.119V2.149h17.194v11.463zm-3.582-7.343v6.262h-2.149V6.269h2.149zm-5.731 0v6.262H9.851V6.269H12z' clipRule='evenodd' /></svg>{event.primary_caster.name}</a>
           : <p className='text-xs italic'>Looking for caster</p> }
 
-        { (event.result && (showSpoilers || reveal) )
+        { (event.result && (showSpoilers || reveal))
           && <p className='flex items-center justify-center w-1/2 px-1 py-1 my-2 ml-auto mr-auto font-bold text-center text-white border border-gray-700 rounded-full md:mt-2 md:mb-1 md:w-full text-2xs'>
             <span className='pl-2 mr-2 -ml-1'>
               <svg class="w-3 text-yellow-3" xmlns="http://www.w3.org/2000/svg" data-name="Layer 1" viewBox="0 0 1456.2 1161.79"><def/><path class="" fill="currentColor" d="M1360.56 626.71c127.52-127.52 127.52-335 0-462.51a325.16 325.16 0 00-107.75-71.57q2-27.11 2.84-54.35A37.21 37.21 0 001218.4 0H237.8a37.21 37.21 0 00-37.25 38.28q.82 27.23 2.84 54.35A325.16 325.16 0 0095.64 164.2c-127.52 127.52-127.52 335 0 462.51 62.66 62.67 189.09 139.61 307.44 187.1 46.74 18.76 100 36.14 152.16 44.45a1210.29 1210.29 0 01-147.7 253.48c-15.48 20.39-1.27 50 24 50h593.16c25.25 0 39.46-29.65 24-50A1210.29 1210.29 0 01901 858.26c52.11-8.31 105.43-25.69 152.16-44.45 118.31-47.49 244.73-124.43 307.4-187.1zM166.83 555.52c-88.26-88.26-88.26-231.87 0-320.13a225.73 225.73 0 0148.7-37C247.16 400.98 325 588.84 430.2 716.17c-115.29-47.83-219.05-116.28-263.37-160.65zm1073.84-357.16a225.73 225.73 0 0148.7 37c88.26 88.26 88.26 231.87 0 320.13-44.27 44.4-148.08 112.85-263.37 160.65 105.2-127.33 183.04-315.19 214.67-517.78z"/></svg>
@@ -300,9 +300,10 @@ function Home () {
     setGuideOptions({ ...guideOptions, showSpoilers: !event.target.checked })
   } 
 
+  // keep cookie consistent w/ user preference  
   useEffect(() => {
     cookie.save('guideOptions', guideOptions)
-  }, [guideOptions])
+  }, [guideOptions]) // eslint-disable-line
 
   const token = cookie.load('token', true)
   return (

--- a/src/screens/Home.js
+++ b/src/screens/Home.js
@@ -43,7 +43,9 @@ function highlightCurrentDayHeader (dayOffset = 0, roundOffset = 0) {
     : 'text-blue-4'
 }
 
-function SingleEvent ({ event }) {
+function SingleEvent ({ event, showSpoilers = true}) {
+  const [reveal, setReveal] = useState(false)
+  const onClick = () => setReveal(true)
   return (
     <EventItem key={`${event.home.name}-${event.away.name}-${event.start_time}`}>
       <p className='py-1 pl-1 text-xs text-yellow-1'>{formatTime(event.start_time)}</p>
@@ -61,22 +63,29 @@ function SingleEvent ({ event }) {
           ? <a target='_blank' rel='noreferrer' className='flex items-center text-xs leading-loose text-purple-400' href={event.primary_caster.stream_link}><svg className='w-3 h-3 mr-1' fill='currentColor' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'> <defs /> <path fillRule='evenodd' d='M2.149 0L.537 4.119v16.836h5.731V24h3.224l3.045-3.045h4.657l6.269-6.269V0H2.149zm19.164 13.612l-3.582 3.582H12l-3.045 3.045v-3.045H4.119V2.149h17.194v11.463zm-3.582-7.343v6.262h-2.149V6.269h2.149zm-5.731 0v6.262H9.851V6.269H12z' clipRule='evenodd' /></svg>{event.primary_caster.name}</a>
           : <p className='text-xs italic'>Looking for caster</p> }
 
-        { event.result
-          ? <p className='flex items-center justify-center w-1/2 px-1 py-1 my-2 ml-auto mr-auto font-bold text-center text-white border border-gray-700 rounded-full md:mt-2 md:mb-1 md:w-full text-2xs'>
+        { (event.result && (showSpoilers || reveal) )
+          && <p className='flex items-center justify-center w-1/2 px-1 py-1 my-2 ml-auto mr-auto font-bold text-center text-white border border-gray-700 rounded-full md:mt-2 md:mb-1 md:w-full text-2xs'>
             <span className='pl-2 mr-2 -ml-1'>
               <svg class="w-3 text-yellow-3" xmlns="http://www.w3.org/2000/svg" data-name="Layer 1" viewBox="0 0 1456.2 1161.79"><def/><path class="" fill="currentColor" d="M1360.56 626.71c127.52-127.52 127.52-335 0-462.51a325.16 325.16 0 00-107.75-71.57q2-27.11 2.84-54.35A37.21 37.21 0 001218.4 0H237.8a37.21 37.21 0 00-37.25 38.28q.82 27.23 2.84 54.35A325.16 325.16 0 0095.64 164.2c-127.52 127.52-127.52 335 0 462.51 62.66 62.67 189.09 139.61 307.44 187.1 46.74 18.76 100 36.14 152.16 44.45a1210.29 1210.29 0 01-147.7 253.48c-15.48 20.39-1.27 50 24 50h593.16c25.25 0 39.46-29.65 24-50A1210.29 1210.29 0 01901 858.26c52.11-8.31 105.43-25.69 152.16-44.45 118.31-47.49 244.73-124.43 307.4-187.1zM166.83 555.52c-88.26-88.26-88.26-231.87 0-320.13a225.73 225.73 0 0148.7-37C247.16 400.98 325 588.84 430.2 716.17c-115.29-47.83-219.05-116.28-263.37-160.65zm1073.84-357.16a225.73 225.73 0 0148.7 37c88.26 88.26 88.26 231.87 0 320.13-44.27 44.4-148.08 112.85-263.37 160.65 105.2-127.33 183.04-315.19 214.67-517.78z"/></svg>
             </span>
             <span className='pr-1'>{event.result.winner}</span>
           </p>
-          : ''
         }
 
+        { (event.result && (!showSpoilers && !reveal)) 
+          && <p className='flex items-center justify-center w-1/2 px-1 py-1 my-2 ml-auto mr-auto font-bold text-center text-white border border-gray-700 rounded-full md:mt-2 md:mb-1 md:w-full text-2xs'>
+              <span className='pl-2 mr-2 -ml-1'>
+              <svg class="w-3 text-yellow-3" xmlns="http://www.w3.org/2000/svg" data-name="Layer 1" viewBox="0 0 1456.2 1161.79"><def/><path class="" fill="currentColor" d="M1360.56 626.71c127.52-127.52 127.52-335 0-462.51a325.16 325.16 0 00-107.75-71.57q2-27.11 2.84-54.35A37.21 37.21 0 001218.4 0H237.8a37.21 37.21 0 00-37.25 38.28q.82 27.23 2.84 54.35A325.16 325.16 0 0095.64 164.2c-127.52 127.52-127.52 335 0 462.51 62.66 62.67 189.09 139.61 307.44 187.1 46.74 18.76 100 36.14 152.16 44.45a1210.29 1210.29 0 01-147.7 253.48c-15.48 20.39-1.27 50 24 50h593.16c25.25 0 39.46-29.65 24-50A1210.29 1210.29 0 01901 858.26c52.11-8.31 105.43-25.69 152.16-44.45 118.31-47.49 244.73-124.43 307.4-187.1zM166.83 555.52c-88.26-88.26-88.26-231.87 0-320.13a225.73 225.73 0 0148.7-37C247.16 400.98 325 588.84 430.2 716.17c-115.29-47.83-219.05-116.28-263.37-160.65zm1073.84-357.16a225.73 225.73 0 0148.7 37c88.26 88.26 88.26 231.87 0 320.13-44.27 44.4-148.08 112.85-263.37 160.65 105.2-127.33 183.04-315.19 214.67-517.78z"/></svg>
+            </span>
+            <span className='pr-1' onClick={onClick}>Click to show winner</span>
+          </p>
+        }
       </div>
     </EventItem>
   )
 }
 
-function TvGuide ({ schedule, roundOffset = 0, loading, scheduleWarning = null }) {
+function TvGuide ({ schedule, roundOffset = 0, loading, scheduleWarning = null, guideOptions = {} }) {
   return (
     <div style={{ backgroundImage: 'repeating-linear-gradient(45deg, #202020, #202020 30px, #222 30px, #222 60px)' }} className='grid grid-cols-1 shadow-lg md:grid-cols-2 lg:grid-cols-7 md:rounded-t-md'>
       <DayColumn>
@@ -88,7 +97,7 @@ function TvGuide ({ schedule, roundOffset = 0, loading, scheduleWarning = null }
           <CalendarEvents>
             { get(schedule, `[${moment().startOf('isoweek').add(roundOffset * 7, 'days').format('YYYYMMDD')}]`, []).map((event) => {
               return (
-                <SingleEvent key={`${event.home.name}-${event.away.name}-${event.start_time}`} event={event} />
+                <SingleEvent key={`${event.home.name}-${event.away.name}-${event.start_time}`} event={event} showSpoilers={guideOptions?.showSpoilers} />
               )
             })}
           </CalendarEvents>
@@ -103,7 +112,7 @@ function TvGuide ({ schedule, roundOffset = 0, loading, scheduleWarning = null }
           <CalendarEvents>
             { get(schedule, `[${moment().startOf('isoweek').add(roundOffset * 7, 'days').add(1, 'days').format('YYYYMMDD')}]`, []).map((event) => {
               return (
-                <SingleEvent key={`${event.home.name}-${event.away.name}-${event.start_time}`} event={event} />
+                <SingleEvent key={`${event.home.name}-${event.away.name}-${event.start_time}`} event={event} showSpoilers={guideOptions?.showSpoilers} />
               )
             })}
           </CalendarEvents>
@@ -118,7 +127,7 @@ function TvGuide ({ schedule, roundOffset = 0, loading, scheduleWarning = null }
           <CalendarEvents>
             { get(schedule, `[${moment().startOf('isoweek').add(roundOffset * 7, 'days').add(2, 'days').format('YYYYMMDD')}]`, []).map((event) => {
               return (
-                <SingleEvent key={`${event.home.name}-${event.away.name}-${event.start_time}`} event={event} />
+                <SingleEvent key={`${event.home.name}-${event.away.name}-${event.start_time}`} event={event} showSpoilers={guideOptions?.showSpoilers} />
               )
             })}
           </CalendarEvents>
@@ -133,7 +142,7 @@ function TvGuide ({ schedule, roundOffset = 0, loading, scheduleWarning = null }
           <CalendarEvents>
             { get(schedule, `[${moment().startOf('isoweek').add(roundOffset * 7, 'days').add(3, 'days').format('YYYYMMDD')}]`, []).map((event) => {
               return (
-                <SingleEvent key={`${event.home.name}-${event.away.name}-${event.start_time}`} event={event} />
+                <SingleEvent key={`${event.home.name}-${event.away.name}-${event.start_time}`} event={event} showSpoilers={guideOptions?.showSpoilers} />
               )
             })}
           </CalendarEvents>
@@ -148,7 +157,7 @@ function TvGuide ({ schedule, roundOffset = 0, loading, scheduleWarning = null }
           <CalendarEvents>
             { get(schedule, `[${moment().startOf('isoweek').add(roundOffset * 7, 'days').add(4, 'days').format('YYYYMMDD')}]`, []).map((event) => {
               return (
-                <SingleEvent key={`${event.home.name}-${event.away.name}-${event.start_time}`} event={event} />
+                <SingleEvent key={`${event.home.name}-${event.away.name}-${event.start_time}`} event={event} showSpoilers={guideOptions?.showSpoilers} />
               )
             })}
           </CalendarEvents>
@@ -163,7 +172,7 @@ function TvGuide ({ schedule, roundOffset = 0, loading, scheduleWarning = null }
           <CalendarEvents>
             { get(schedule, `[${moment().startOf('isoweek').add(roundOffset * 7, 'days').add(5, 'days').format('YYYYMMDD')}]`, []).map((event) => {
               return (
-                <SingleEvent key={`${event.home.name}-${event.away.name}-${event.start_time}`} event={event} />
+                <SingleEvent key={`${event.home.name}-${event.away.name}-${event.start_time}`} event={event} showSpoilers={guideOptions?.showSpoilers} />
               )
             })}
           </CalendarEvents>
@@ -178,7 +187,7 @@ function TvGuide ({ schedule, roundOffset = 0, loading, scheduleWarning = null }
           <CalendarEvents>
             { get(schedule, `[${moment().startOf('isoweek').add(roundOffset * 7, 'days').add(6, 'days').format('YYYYMMDD')}]`, []).map((event) => {
               return (
-                <SingleEvent key={`${event.home.name}-${event.away.name}-${event.start_time}`} event={event} />
+                <SingleEvent key={`${event.home.name}-${event.away.name}-${event.start_time}`} event={event} showSpoilers={guideOptions?.showSpoilers} />
               )
             })}
           </CalendarEvents>
@@ -219,6 +228,9 @@ function Home () {
   const [currentRoundName, setCurrentRoundName] = useState()
   const [activeRound, setActiveRound] = useState()
   const [roundOffset, setRoundOffset] = useState(0)
+  // create userGuide cookie if needed; default to `{showSpoilers: true}` to preserve existing behavior
+  const [guideOptions, setGuideOptions] = useState(
+    cookie.save('guideOptions', {showSpoilers: true, ...cookie.load('guideOptions')}) || cookie.load('guideOptions'))
   let userId = cookie.load('userId')
   useEffect(() => {
     const fetchData = async () => {
@@ -283,6 +295,14 @@ function Home () {
         .catch(handleError)
     }
   }, [roundOffset]) // eslint-disable-line
+
+  function handleSpoilersChange(event) {
+    setGuideOptions({ ...guideOptions, showSpoilers: !event.target.checked })
+  } 
+
+  useEffect(() => {
+    cookie.save('guideOptions', guideOptions)
+  }, [guideOptions])
 
   const token = cookie.load('token', true)
   return (
@@ -364,13 +384,16 @@ function Home () {
 
               <PageTitle className='flex justify-between mt-8'>
                 {currentRoundName ? `${currentRoundName}` : `Week of ${moment().startOf('isoweek').add(roundOffset * 7, 'days').format('M/D')}`}
+                <div class='flex text-sm px-2'>
+                 Hide Spoilers: <input type='checkbox' className='' checked={!guideOptions.showSpoilers} onChange={handleSpoilersChange} />
+                </div>
                 <div class="flex items-center">
                   <button className='px-2 ml-4 text-sm border border-gray-700 focus:outline-none focus:ring-1 rounded-l-md rounded-r-md hover:border-gray-500 focus:ring-gray-400 focus:border-black' onClick={() => pageTvGuide(roundOffset - 1)}>{'◁'}</button>
                   <button className='px-2 ml-1 text-sm border border-gray-700 focus:outline-none focus:ring-1 rounded-l-md rounded-r-md hover:border-gray-500 focus:ring-gray-400 focus:border-black' onClick={() => pageTvGuide(0)}>{'Current Week'}</button>
                   <button className='px-2 ml-1 text-sm transform rotate-180 border border-gray-700 focus:outline-none focus:ring-1 rounded-l-md rounded-r-md hover:border-gray-500 focus:ring-gray-400 focus:border-black' onClick={() => pageTvGuide(roundOffset + 1)}>{'◁'}</button>
                 </div>
               </PageTitle>
-              <TvGuide schedule={schedule} roundOffset={roundOffset} loading={tvLoading} scheduleWarning={scheduleWarning} />
+              <TvGuide schedule={schedule} roundOffset={roundOffset} loading={tvLoading} scheduleWarning={scheduleWarning} guideOptions={guideOptions} />
             </div>
 
           )


### PR DESCRIPTION
The TV Guide on the homepage is super helpful in finding games to watch, but when watching games that have already happened, it is all too easy to see who the winner was while trying to get the Twitch channel. This PR will allow users to opt-in to having spoilers hidden.

Feature details:
- Added option to hide spoilers just above the TV Guide on the homepage
  - The default option is not to hide spoilers (aka show spoilers), this preserves existing behavior
  - When spoilers are hidden, a user must click to reveal the winner of a match
  - The user's spoiler preference is stored as a cookie to persist selection between visits

What's left to do:
- Find an aesthetically pleasing way to display the spoiler checkbox; current checkbox is unstyled (I would like guidance on this)

I have not used Tailwind CSS before so guidance/help on how to style the checkbox and text would be amazing! I am happy to make any other suggested changes-just let me know!
