### PR TITLE
Matches page is incorrectly empty before matches are scheduled

### DIFF
--- a/src/screens/Team.js
+++ b/src/screens/Team.js
@@ -343,8 +343,8 @@ function Team () {
                         )
                         : (
                             <>
-                              <span>You have no match this week</span>
-                              <span className='text-xs'>(That may be because you have a Bye week)</span>
+                              <br/>
+                              <span className='text-gray-500'>No matches are currently scheduled</span>
                             </>
                         )
                     }


### PR DESCRIPTION
Before this patch (hidden text, 👻 ):
<img width="1654" alt="Screen Shot 2022-01-12 at 3 48 02 PM" src="https://user-images.githubusercontent.com/1693224/149240984-58fa4407-69d1-46ea-8755-85916c5fde71.png">

<img width="1067" alt="Screen Shot 2022-01-12 at 3 48 06 PM" src="https://user-images.githubusercontent.com/1693224/149240992-72b6cc83-6eda-4174-a2d0-14e41f614e7e.png">



With this patch:
<img width="1594" alt="Screen Shot 2022-01-12 at 3 45 05 PM" src="https://user-images.githubusercontent.com/1693224/149240895-31aa4f38-05b4-49b9-abaa-65c3fe9b4076.png">
