### PR TITLE
Sort by dates and then team name

### DIFF
--- a/src/screens/Home.js
+++ b/src/screens/Home.js
@@ -142,7 +142,7 @@ function sortEventsIntoDates (events) {
 
   // force sort these if the API has returned them in a weird order
   Object.keys(sorted).forEach((key) => {
-    sorted[key] = sortBy(sorted[key], ['start_time'])
+    sorted[key] = sortBy(sorted[key], ['start_time', 'away.name'])
   })
 
   return sorted


### PR DESCRIPTION
When you have multiple games at the same time on the TV Guide, they sometimes appear in a different order on page reload.  This adds a second sort order to make it static and consistent between page reloads