### PR TITLE
Home page game list (for the player) should only show matches from the active season

### DIFF
--- a/src/screens/Home.js
+++ b/src/screens/Home.js
@@ -173,7 +173,7 @@ function Home () {
           .then(data => setProfile(data))
           .catch(handleError))
 
-        promises.push(fetch(`${getApiUrl()}matches/?round_is_current=true&player=${userId}`)
+        promises.push(fetch(`${getApiUrl()}matches/?round_is_current=true&player=${userId}&season_is_active=true`)
           .then(data => data.json())
           .then(data => setPlayerMatches(data.results))
           .catch(handleError))


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1693224/158948406-c72a827f-6125-4070-9eac-79a550bb64e5.png)

Looked like this before Bee's marked berry season as round 0.  She had already marked it as "not active."